### PR TITLE
Handle escaped forward slashes, which some json libraries add.

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -219,6 +219,7 @@ namespace ijson {
     COLON = makeClass(":"),
     DQUOTE = makeClass("\""),
     BSLASH = makeClass("\\"),
+    FSLASH = makeClass("/"),
     SPACE = makeClass(" \t\r"),
     NL = makeClass("\n"),
     t_ = makeClass("t"),
@@ -425,6 +426,12 @@ namespace ijson {
 
   void inline escapeBSLASH(Parser* parser, int pos, int cla) {
     parser->keep.push_back('\\');
+    parser->beg = pos + 1;
+    parser->state = INSIDE_QUOTES;
+  }
+
+  void inline escapeFSLASH(Parser* parser, int pos, int cla) {
+    parser->keep.push_back('/');
     parser->beg = pos + 1;
     parser->state = INSIDE_QUOTES;
   }
@@ -642,6 +649,7 @@ namespace ijson {
       { t_, escapeT },
       { DQUOTE, escapeDQUOTE },
       { BSLASH, escapeBSLASH },
+      { FSLASH, escapeFSLASH },
       { u_, u_xxxx }, 
       { -1, NULL }
     };

--- a/test/test.js
+++ b/test/test.js
@@ -196,3 +196,21 @@ test("callback no return", 10, function() {
 	strictEqual(results[7], ': {}');
 	strictEqual(JSON.stringify(parser.result()), undefined);
 });
+
+test("escaped forward slash", 10, function() {
+	var results = [];
+	var parser = ijson.createParser(function(result, path) {
+		results.push(path.join('/') + ': ' + JSON.stringify(result));
+	});
+	parser.update('{"data": [2, 3, [true, false]], "message": "hello\/goodbye" }');
+	strictEqual(results.length, 8);
+	strictEqual(results[0], 'data/0: 2');
+	strictEqual(results[1], 'data/1: 3');
+	strictEqual(results[2], 'data/2/0: true');
+	strictEqual(results[3], 'data/2/1: false');
+	strictEqual(results[4], 'data/2: []');
+	strictEqual(results[5], 'data: []');
+	strictEqual(results[6], 'message: "hello/goodbye"');
+	strictEqual(results[7], ': {}');
+	strictEqual(JSON.stringify(parser.result()), undefined);
+});


### PR DESCRIPTION
Handle escaped forward slashes.  Some libraries escape forward slashes because some(?) browsers don't allow forward slashes in strings inside a script tag.

http://stackoverflow.com/questions/1580647/json-why-are-forward-slashes-escaped